### PR TITLE
Update Android.bp

### DIFF
--- a/services/audiopolicy/config/Android.bp
+++ b/services/audiopolicy/config/Android.bp
@@ -15,6 +15,10 @@
  */
 
 soong_namespace {
+    imports: [
+        "hardware/google/interfaces",
+        "hardware/google/pixel",
+    ],
 }
 
 package {


### PR DESCRIPTION
soong_namespace {
    imports: [
        "hardware/google/interfaces",
        "hardware/google/pixel",
    ],
}

missing