### PR TITLE
HACK: libcameraservice: Make system cameras available to all camera apps

### DIFF
--- a/camera/CameraMetadata.cpp
+++ b/camera/CameraMetadata.cpp
@@ -880,7 +880,7 @@ status_t CameraMetadata::getTagFromName(const char *name,
     return OK;
 }
 
-metadata_vendor_id_t CameraMetadata::getVendorId() {
+metadata_vendor_id_t CameraMetadata::getVendorId() const {
     return get_camera_metadata_vendor_id(mBuffer);
 }
 

--- a/camera/VendorTagDescriptor.cpp
+++ b/camera/VendorTagDescriptor.cpp
@@ -466,7 +466,7 @@ const char* VendorTagDescriptorCache::getTagName(uint32_t tag,
 
 int VendorTagDescriptorCache::getTagType(uint32_t tag,
         metadata_vendor_id_t id) const {
-    int ret = 0;
+    int ret = -1;
     auto desc = mVendorMap.find(id);
     if (desc != mVendorMap.end()) {
         ret = desc->second->getTagType(tag);

--- a/camera/include/camera/CameraMetadata.h
+++ b/camera/include/camera/CameraMetadata.h
@@ -245,7 +245,7 @@ class CameraMetadata: public Parcelable {
     /**
      * Return the current vendor tag id associated with this metadata.
      */
-    metadata_vendor_id_t getVendorId();
+    metadata_vendor_id_t getVendorId() const;
 
   private:
     camera_metadata_t *mBuffer;

--- a/media/libaaudio/src/utility/AAudioUtilities.cpp
+++ b/media/libaaudio/src/utility/AAudioUtilities.cpp
@@ -261,7 +261,7 @@ audio_flags_mask_t AAudio_computeAudioFlagsMask(
         bool isContentSpatialized,
         audio_output_flags_t outputFlags) {
     audio_flags_mask_t flagsMask = AUDIO_FLAG_NONE;
-    switch (policy) {
+    /*switch (policy) {
         case AAUDIO_UNSPECIFIED:
         case AAUDIO_ALLOW_CAPTURE_BY_ALL:
             // flagsMask is not modified
@@ -276,7 +276,7 @@ audio_flags_mask_t AAudio_computeAudioFlagsMask(
         default:
             ALOGE("%s() 0x%08X unrecognized capture policy", __func__, policy);
             // flagsMask is not modified
-    }
+    }*/
 
     switch (spatializationBehavior) {
         case AAUDIO_UNSPECIFIED:

--- a/media/libmediaplayerservice/StagefrightRecorder.cpp
+++ b/media/libmediaplayerservice/StagefrightRecorder.cpp
@@ -1111,6 +1111,8 @@ status_t StagefrightRecorder::setParameter(
         }
     } else if (key == "log-session-id") {
         return setLogSessionId(value);
+    } else if (key == "set-title") {
+        return OK;
     } else {
         ALOGE("setParameter: failed to find key %s", key.c_str());
     }

--- a/media/libstagefright/omx/SoftOMXPlugin.cpp
+++ b/media/libstagefright/omx/SoftOMXPlugin.cpp
@@ -61,6 +61,9 @@ static const struct {
     { "OMX.google.flac.decoder", "flacdec", "audio_decoder.flac" },
     { "OMX.google.flac.encoder", "flacenc", "audio_encoder.flac" },
     { "OMX.google.gsm.decoder", "gsmdec", "audio_decoder.gsm" },
+    { "OMX.dolby.ac3.decoder", "ddpdec", "audio_decoder.ac3" },
+    { "OMX.dolby.eac3-joc.decoder", "ddpdec", "audio_decoder.eac3_joc" },
+    { "OMX.dolby.eac3.decoder", "ddpdec", "audio_decoder.eac3" },
 };
 
 static const size_t kNumComponents =

--- a/media/libstagefright/wifi-display/source/WifiDisplaySource.cpp
+++ b/media/libstagefright/wifi-display/source/WifiDisplaySource.cpp
@@ -79,11 +79,11 @@ WifiDisplaySource::WifiDisplaySource(
     mSupportedSourceVideoFormats.disableAll();
 
     mSupportedSourceVideoFormats.setNativeResolution(
-            VideoFormats::RESOLUTION_CEA, 5);  // 1280x720 p30
+            VideoFormats::RESOLUTION_CEA, 8);  // 1920x1080p60
 
-    // Enable all resolutions up to 1280x720p30
+    // Enable all resolutions up to 1920x1080p60
     mSupportedSourceVideoFormats.enableResolutionUpto(
-            VideoFormats::RESOLUTION_CEA, 5,
+            VideoFormats::RESOLUTION_CEA, 8,
             VideoFormats::PROFILE_CHP,  // Constrained High Profile
             VideoFormats::LEVEL_32);    // Level 3.2
 }

--- a/media/libstagefright/wifi-display/source/WifiDisplaySource.cpp
+++ b/media/libstagefright/wifi-display/source/WifiDisplaySource.cpp
@@ -78,12 +78,14 @@ WifiDisplaySource::WifiDisplaySource(
 
     mSupportedSourceVideoFormats.disableAll();
 
-    mSupportedSourceVideoFormats.setNativeResolution(
-            VideoFormats::RESOLUTION_CEA, 8);  // 1920x1080p60
+    // Set default all resolutions up to 1920x1080p60
+    int32_t maxWfdRes = property_get_int32("media.wfd.max_resolution", 8); // 1920x1080p60
 
-    // Enable all resolutions up to 1920x1080p60
+    mSupportedSourceVideoFormats.setNativeResolution(
+            VideoFormats::RESOLUTION_CEA, maxWfdRes);
+
     mSupportedSourceVideoFormats.enableResolutionUpto(
-            VideoFormats::RESOLUTION_CEA, 8,
+            VideoFormats::RESOLUTION_CEA, maxWfdRes,
             VideoFormats::PROFILE_CHP,  // Constrained High Profile
             VideoFormats::LEVEL_32);    // Level 3.2
 }

--- a/services/audioflinger/Effects.cpp
+++ b/services/audioflinger/Effects.cpp
@@ -2805,6 +2805,11 @@ static const effect_uuid_t SL_IID_VOLUME_ = { 0x09e8ede0, 0xddde, 0x11db, 0xb4f6
 const effect_uuid_t * const SL_IID_VOLUME = &SL_IID_VOLUME_;
 #endif //OPENSL_ES_H_
 
+// Dolby Atmos
+static const effect_uuid_t SL_IID_DAP_ = // 46d279d9-9be7-453d-9d7c-ef937f675587
+{ 0x46d279d9, 0x9be7, 0x453d, 0x9d7c, {0xef, 0x93, 0x7f, 0x67, 0x55, 0x87} };
+const effect_uuid_t * const SL_IID_DAP = &SL_IID_DAP_;
+
 /* static */
 bool EffectChain::isEffectEligibleForBtNrecSuspend(const effect_uuid_t *type)
 {
@@ -2823,7 +2828,8 @@ bool EffectChain::isEffectEligibleForSuspend(const effect_descriptor_t& desc)
         (((desc.flags & EFFECT_FLAG_TYPE_MASK) == EFFECT_FLAG_TYPE_AUXILIARY) ||
          (memcmp(&desc.type, SL_IID_VISUALIZATION, sizeof(effect_uuid_t)) == 0) ||
          (memcmp(&desc.type, SL_IID_VOLUME, sizeof(effect_uuid_t)) == 0) ||
-         (memcmp(&desc.type, SL_IID_DYNAMICSPROCESSING, sizeof(effect_uuid_t)) == 0))) {
+         (memcmp(&desc.type, SL_IID_DYNAMICSPROCESSING, sizeof(effect_uuid_t)) == 0) ||
+         (memcmp(&desc.type, SL_IID_DAP, sizeof(effect_uuid_t)) == 0))) {
         return false;
     }
     return true;

--- a/services/audiopolicy/common/managerdefinitions/src/AudioPolicyMix.cpp
+++ b/services/audiopolicy/common/managerdefinitions/src/AudioPolicyMix.cpp
@@ -408,30 +408,6 @@ bool AudioPolicyMixCollection::mixMatch(const AudioMix* mix, size_t mixIndex,
     uid_t uid, audio_session_t session) {
 
     if (mix->mMixType == MIX_TYPE_PLAYERS) {
-        // Loopback render mixes are created from a public API and thus restricted
-        // to non sensible audio that have not opted out.
-        if (is_mix_loopback_render(mix->mRouteFlags)) {
-            if (!(attributes.usage == AUDIO_USAGE_UNKNOWN ||
-                  attributes.usage == AUDIO_USAGE_MEDIA ||
-                  attributes.usage == AUDIO_USAGE_GAME ||
-                  attributes.usage == AUDIO_USAGE_VOICE_COMMUNICATION)) {
-                return false;
-            }
-            auto hasFlag = [](auto flags, auto flag) { return (flags & flag) == flag; };
-            if (hasFlag(attributes.flags, AUDIO_FLAG_NO_SYSTEM_CAPTURE)) {
-                return false;
-            }
-
-            if (attributes.usage == AUDIO_USAGE_VOICE_COMMUNICATION) {
-                if (!mix->mVoiceCommunicationCaptureAllowed) {
-                    return false;
-                }
-            } else if (!mix->mAllowPrivilegedMediaPlaybackCapture &&
-                hasFlag(attributes.flags, AUDIO_FLAG_NO_MEDIA_PROJECTION)) {
-                return false;
-            }
-        }
-
         // Permit match only if requested format and mix format are PCM and can be format
         // adapted by the mixer, or are the same (compressed) format.
         if (!is_mix_loopback(mix->mRouteFlags) &&

--- a/services/camera/libcameraservice/Android.bp
+++ b/services/camera/libcameraservice/Android.bp
@@ -118,10 +118,12 @@ cc_defaults {
 
 cc_library {
     name: "libcameraservice",
-
     defaults: [
         "libcameraservice_deps",
+        "uses_oplus_camera_defaults",
+        "uses_nothing_camera_defaults",
     ],
+
     // Camera service source
 
     srcs: [

--- a/services/camera/libcameraservice/CameraService.cpp
+++ b/services/camera/libcameraservice/CameraService.cpp
@@ -151,6 +151,9 @@ const std::string CameraService::kWatchAllClientsFlag("all");
 // Set to keep track of logged service error events.
 static std::set<std::string> sServiceErrorEventSet;
 
+// Current camera package name
+static std::string sCurrPackageName;
+
 CameraService::CameraService(
         std::shared_ptr<CameraServiceProxyWrapper> cameraServiceProxyWrapper) :
         mCameraServiceProxyWrapper(cameraServiceProxyWrapper == nullptr ?
@@ -1447,6 +1450,10 @@ Status CameraService::filterGetInfoErrorCode(status_t err) {
     }
 }
 
+std::string CameraService::getCurrPackageName() {
+    return sCurrPackageName;
+}
+
 Status CameraService::makeClient(const sp<CameraService>& cameraService,
         const sp<IInterface>& cameraCb, const std::string& packageName, bool systemNativeClient,
         const std::optional<std::string>& featureId,  const std::string& cameraId,
@@ -2403,6 +2410,8 @@ Status CameraService::connectHelper(const sp<CALLBACK>& cameraCb, const std::str
     ALOGI("CameraService::connect call (PID %d \"%s\", camera ID %s) and "
             "Camera API version %d", packagePid, clientPackageName.c_str(), cameraId.c_str(),
             static_cast<int>(effectiveApiLevel));
+
+    sCurrPackageName = clientPackageName;
 
     nsecs_t openTimeNs = systemTime();
 

--- a/services/camera/libcameraservice/CameraService.cpp
+++ b/services/camera/libcameraservice/CameraService.cpp
@@ -803,11 +803,9 @@ bool CameraService::hasPermissionsForSystemCamera(const std::string& cameraId, i
     AttributionSourceState attributionSource{};
     attributionSource.pid = callingPid;
     attributionSource.uid = callingUid;
-    bool checkPermissionForSystemCamera = checkPermission(cameraId,
-            sSystemCameraPermission, attributionSource, std::string(), AppOpsManager::OP_NONE);
     bool checkPermissionForCamera = checkPermission(cameraId,
             sCameraPermission, attributionSource, std::string(), AppOpsManager::OP_NONE);
-    return checkPermissionForSystemCamera && checkPermissionForCamera;
+    return checkPermissionForCamera;
 }
 
 bool CameraService::hasPermissionsForCameraHeadlessSystemUser(const std::string& cameraId,

--- a/services/camera/libcameraservice/CameraService.h
+++ b/services/camera/libcameraservice/CameraService.h
@@ -309,6 +309,8 @@ public:
     // Shared utilities
     static binder::Status filterGetInfoErrorCode(status_t err);
 
+    static std::string getCurrPackageName();
+
     /////////////////////////////////////////////////////////////////////
     // CameraClient functionality
 

--- a/services/camera/libcameraservice/device3/Camera3Device.cpp
+++ b/services/camera/libcameraservice/device3/Camera3Device.cpp
@@ -25,6 +25,13 @@
 #define ALOGVV(...) ((void)0)
 #endif
 
+#ifdef USES_OPLUS_CAMERA
+#define TAG_NAME "com.oplus.packageName"
+#endif
+#ifdef USES_NOTHING_CAMERA
+#define TAG_NAME "com.nothing.device.package_name"
+#endif
+
 // Convenience macro for transient errors
 #define CLOGE(fmt, ...) ALOGE("Camera %s: %s: " fmt, mId.c_str(), __FUNCTION__, \
             ##__VA_ARGS__)
@@ -2406,6 +2413,27 @@ status_t Camera3Device::configureStreamsLocked(int operatingMode,
         CLOGE("Invalid operating mode: %d", operatingMode);
         return BAD_VALUE;
     }
+
+#ifdef TAG_NAME
+    sp<VendorTagDescriptor> vTags;
+    sp<VendorTagDescriptorCache> vCache = VendorTagDescriptorCache::getGlobalVendorTagCache();
+    if (vCache.get()) {
+        const camera_metadata_t *metaBuffer = sessionParams.getAndLock();
+        metadata_vendor_id_t vendorId = get_camera_metadata_vendor_id(metaBuffer);
+        sessionParams.unlock(metaBuffer);
+        vCache->getVendorTagDescriptor(vendorId, &vTags);
+        uint32_t tag;
+        if (CameraMetadata::getTagFromName(TAG_NAME, vTags.get(), &tag)) {
+            ALOGE("%s: Unable to get %s tag", __FUNCTION__, TAG_NAME);
+        } else {
+            std::string pkgName = CameraService::getCurrPackageName();
+            status_t res = const_cast<CameraMetadata&>(sessionParams).update(tag, String8(pkgName.c_str()));
+            if (res) {
+                ALOGE("%s: metadata update failed, res = %d", __FUNCTION__, res);
+            }
+        }
+    }
+#endif
 
     bool isConstrainedHighSpeed =
             CAMERA_STREAM_CONFIGURATION_CONSTRAINED_HIGH_SPEED_MODE == operatingMode;


### PR DESCRIPTION
 * big brained realmeme decided to move aux cams to "system-only cameras" utilizing the new permission introduced in android 11, thereby breaking aux cams in 3rd party camera apps like gcam

 * lets avoid this and make system camera accessible to all camera apps; legacy apps still wont break because of the aux cams check in fwb

Test: manual, aux cameras accessible by gcam on realme X3
Change-Id: I5db53ffe91a8c28972f1c58bd228cb0f79d7183a